### PR TITLE
Update node 18 for upgrade to expo SDK 50

### DIFF
--- a/provisioning/roles/js/tasks/main.yml
+++ b/provisioning/roles/js/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: put nodesource repository
   apt_repository:
-    repo: "deb https://deb.nodesource.com/node_16.x {{ ansible_distribution_release }} main"
+    repo: "deb https://deb.nodesource.com/node_18.x {{ ansible_distribution_release }} main"
     state: present
 
 - name: install nodejs and npm from repo


### PR DESCRIPTION
Why we need to upgrade 
```
error @react-native/babel-preset@0.73.19: The engine "node" is incompatible with this module. Expected version ">=18". Got "16.15.1"
Done in 8.08s.
Error: Found incompatible module.
    at MessageError.ExtendableBuiltin (/usr/share/yarn/lib/cli.js:721:66)
    at new MessageError (/usr/share/yarn/lib/cli.js:750:123)
    at checkOne (/usr/share/yarn/lib/cli.js:47864:11)
    at Object.check (/usr/share/yarn/lib/cli.js:47883:5)
    at /usr/share/yarn/lib/cli.js:7352:73
    at Generator.next (<anonymous>)
    at step (/usr/share/yarn/lib/cli.js:310:30)
    at /usr/share/yarn/lib/cli.js:321:13
```
At `yarn upgrade-interactive --latest` 
> Choose which packages to update. expo@50.0.3



Previously 
> use node 16 , because expo-cli still does not support node 18 

https://github.com/allan-simon/docker-dev-js/commit/9044d1d0708ca20f9d30c6b8d4c51b8ce703e87c



Now officially supported since new Expo local CLI 0.14.0 — 2023-10-17 https://github.com/expo/expo/blob/main/packages/%40expo/cli/CHANGELOG.md

> Transpile for Node 18 (LTS)


Note about Expo Cli :

Our package json doesn't contain any trace of deprecated expo-cli only to `expo@^49.0.8:"@expo/cli" "0.10.16"`

So we did not specifically rely on deprecated cli

https://github.com/expo/expo-cli

> The modern local Expo CLI is included with the expo package and does not need to be installed separately. Run it with npx expo. Its source code lives in the expo/expo repo.